### PR TITLE
fixed level_loaded import

### DIFF
--- a/BuildFunctions/level_loader.py
+++ b/BuildFunctions/level_loader.py
@@ -9,7 +9,7 @@ from Entities.door import Door
 from Entities.coins import Coins
 from Entities.spike import Spike
 from Entities.trophies import Trophy
-from Display.display import Display
+from display.display import Display
 from BuildFunctions.directory import Directory
 
 Display = Display()


### PR DESCRIPTION
from Display.display import Display
ModuleNotFoundError: No module named 'Display' -> foldername is lower case